### PR TITLE
Allow to clone a single branch instead the full repository.

### DIFF
--- a/seuac-git-plugin/README.md
+++ b/seuac-git-plugin/README.md
@@ -64,9 +64,10 @@ Property name | Type | Default value | Description
 `git` | NamedDomainObjectContainer<GitRepository> | - | Contains the named Git repository definitions.
 `url` | String | - | The URL of the named Git repository. Include username and password in the URL.
 `directory` | File | - | The local directory of the named Git repository.
-`branch` | String | - | The branch name to use. Defaults to HEAD.
+`branch` | String | - | The branch name to use. Defaults to HEAD. If `singleBranch` is `true` this must be a valid refspec like `refs/heads/BRANCHNAME`.
 `username` | String | - | The username used for authentication.
 `password` | String | - | The password used for authentication.
+`singleBranch` | Boolean | `false` | Should only clone the specified branch.
 
 ### Example
 
@@ -80,6 +81,7 @@ git {
         branch 'HEAD'
         username gitUsername
         password gitPassword
+        singleBranch false
     }
 }
 ```

--- a/seuac-git-plugin/gradle.properties
+++ b/seuac-git-plugin/gradle.properties
@@ -1,4 +1,4 @@
-version=2.1.1
+version=2.1.2-SNAPSHOT
 
 displayName=Gradle Git plugin
 description=A Gradle plugin for handling Git repositories.

--- a/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitCloneTask.groovy
+++ b/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitCloneTask.groovy
@@ -31,6 +31,8 @@ class GitCloneTask extends AbstractGitTask {
     String url
     @Input
     String branch
+    @Input
+    boolean singleBranch
 
     @TaskAction
     def doClone() {
@@ -42,6 +44,12 @@ class GitCloneTask extends AbstractGitTask {
 
             clone.setURI(url).setDirectory(directory).setBranch(branch).setBare(false)
             clone.setCredentialsProvider(createCredentialsProvider())
+
+            if (singleBranch && branch.startsWith("refs/")) {
+                clone.cloneAllBranches = false
+                clone.branchesToClone = [branch]
+            }
+
             repository = clone.call().getRepository()
         } always {
             if (repository) {
@@ -49,5 +57,4 @@ class GitCloneTask extends AbstractGitTask {
             }
         }
     }
-
 }

--- a/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitPlugin.groovy
+++ b/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitPlugin.groovy
@@ -118,6 +118,7 @@ class GitPlugin implements Plugin<Project> {
             branch = repo.branch
             username = repo.username
             password = repo.password
+            singleBranch = repo.singleBranch
         }
         project.tasks.gitCloneAll.dependsOn gitClone
     }

--- a/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitRepository.groovy
+++ b/seuac-git-plugin/src/main/groovy/de/qaware/seu/as/code/plugins/git/GitRepository.groovy
@@ -27,6 +27,7 @@ class GitRepository {
     File directory
     String username
     String password
+    boolean singleBranch = false
 
     /**
      * Required to construct by name.
@@ -89,5 +90,14 @@ class GitRepository {
      */
     void password(String aPassword) {
         this.password = aPassword
+    }
+
+    /**
+     * Shorthand method to set the single branch only option.
+     *
+     * @param singleBranch only clone the single branch
+     */
+    void singleBranch(boolean singleBranch) {
+        this.singleBranch = singleBranch
     }
 }

--- a/seuac-git-plugin/src/test/groovy/de/qaware/seu/as/code/plugins/git/GitCloneTaskSpec.groovy
+++ b/seuac-git-plugin/src/test/groovy/de/qaware/seu/as/code/plugins/git/GitCloneTaskSpec.groovy
@@ -84,4 +84,23 @@ class GitCloneTaskSpec extends Specification {
         expect project.tasks.testGitClone, notNullValue()
         thrown(GradleException)
     }
+
+    def "Invoke doClone with single task"() {
+        expect:
+        that project.tasks.findByName(TEST_GIT_CLONE), is(nullValue())
+
+        when:
+        project.configurations.create('jgit')
+        GitCloneTask task = project.task(TEST_GIT_CLONE, type: GitCloneTask) {
+            url = "https://github.com/qaware/QAseuac.git"
+            directory = this.directory
+            singleBranch = true
+            branch = "refs/heads/base-plugin"
+        }
+        task.doClone()
+
+        then:
+        expect project.tasks.testGitClone, notNullValue()
+        thrown(GradleException)
+    }
 }


### PR DESCRIPTION
Extends the git plugin to define that a clone should only download the specified branch instead the full repository.
